### PR TITLE
Remove objectAssign

### DIFF
--- a/src/Feliz.ReactFlow/Interop.fs
+++ b/src/Feliz.ReactFlow/Interop.fs
@@ -11,9 +11,6 @@ module Interop =
     let objectHas (keys: string list) (x: obj) =
         objectKeys (x) |> Seq.toList |> (=) keys
 
-    [<Emit("Object.assign({}, $0, $1)")>]
-    let objectAssign (x: obj) (y: obj) = jsNative
-
     let inline mkNodeAttr (key: string) (value: obj) : INodeProp = unbox (key, value)
     let reactFlow : obj = importDefault "react-flow-renderer" // import the top-level ReactFlow element
 

--- a/src/Feliz.ReactFlow/ReactFlow.fs
+++ b/src/Feliz.ReactFlow/ReactFlow.fs
@@ -29,10 +29,11 @@ type ReactFlow =
         Interop.reactApi.createElement (Interop.reactFlow, createObj !!props)
 
     static member inline node props =
-        Interop.objectAssign obj (createObj !!props)
+        createObj !!props
 
     static member inline edge props =
-        Interop.objectAssign obj (createObj !!props)
+        createObj !!props
+
     /// Provides the child elements in a flow.
     static member inline elements(elements: obj array) : IReactFlowProp = !!("elements" ==> elements)
 


### PR DESCRIPTION
Sometimes wrong code was being generated and seems it was because of the `objectAssign` helper. I've tested it and removing it makes things work :+1: