### PR TITLE
Fixes and additional bindings

### DIFF
--- a/src/Client/Index.fs
+++ b/src/Client/Index.fs
@@ -33,11 +33,15 @@ let Counter() =
     ]
 
 let view (model: Model) (dispatch: Msg -> unit) =
+    let gridSize = 20
+
     div [ Props.Style [
-              Props.CSSProp.Height 1000
+              Props.CSSProp.Height 800
           ] ] [
         ReactFlow.flowChart [
             ReactFlow.nodeTypes {| test = Counter |}
+            ReactFlow.snapGrid (gridSize, gridSize)
+            ReactFlow.snapToGrid true
             ReactFlow.elements [|
                 ReactFlow.node [
                     node.id "1"
@@ -168,5 +172,22 @@ let view (model: Model) (dispatch: Msg -> unit) =
                 (fun ev nodeId ->
                     console.log ev
                     window.alert "You started to connect me!")
+            ReactFlow.children [
+                ReactFlow.background [
+                    background.gap gridSize
+                    background.size 1.
+                    background.variant Dots
+                    background.color "lightgrey"
+                ]
+                ReactFlow.miniMap [
+                    miniMap.nodeColor "lightgreen"
+                    miniMap.maskColor "gray"
+                ]
+                ReactFlow.controls [
+                    controls.onZoomIn (fun () -> console.log("Zoomed in"))
+                    controls.onZoomOut (fun () -> console.log("Zoomed out"))
+                    controls.onInteractiveChange (fun status -> console.log($"Locked: {not status}"))
+                ]
+            ]
         ]
     ]

--- a/src/Feliz.ReactFlow/Components.fs
+++ b/src/Feliz.ReactFlow/Components.fs
@@ -1,0 +1,107 @@
+namespace Feliz.ReactFlow
+
+open Fable.Core
+open Fable.Core.JsInterop
+open Feliz
+
+[<StringEnum>]
+type BackgroundVariant =
+    | Dots
+    | Lines
+
+[<Erase>]
+type background =
+    // https://reactflow.dev/docs/api/components/background/
+
+    static member inline variant(variant: BackgroundVariant): IBackgroundProp =
+        Interop.mkBackgroundProp "variant" variant
+
+    static member inline gap(gap: int): IBackgroundProp =
+        Interop.mkBackgroundProp "gap" gap
+
+    static member inline gap(gap: float): IBackgroundProp =
+        Interop.mkBackgroundProp "gap" gap
+
+    static member inline size(size: int): IBackgroundProp =
+        Interop.mkBackgroundProp "size" size
+
+    static member inline size(size: float): IBackgroundProp =
+        Interop.mkBackgroundProp "size" size
+
+    static member inline color(color: string): IBackgroundProp =
+        Interop.mkBackgroundProp "color" color
+
+    static member inline style props: IBackgroundProp =
+        Interop.mkBackgroundProp "style" (createObj !!props)
+
+    static member inline className(className: string): IBackgroundProp =
+        Interop.mkBackgroundProp "className" className
+
+[<Erase>]
+type miniMap =
+    // https://reactflow.dev/docs/api/components/minimap/
+
+    static member inline nodeColor(nodeColor: string): IMiniMapProp =
+        Interop.mkMiniMapProp "nodeColor" nodeColor
+
+    static member inline nodeColor(nodeColor: Node -> string): IMiniMapProp =
+        Interop.mkMiniMapProp "nodeColor" nodeColor
+
+    static member inline nodeBorderRadius(nodeBorderRadius: int): IMiniMapProp =
+        Interop.mkMiniMapProp "nodeBorderRadius" nodeBorderRadius
+
+    static member inline nodeBorderRadius(nodeBorderRadius: float): IMiniMapProp =
+        Interop.mkMiniMapProp "nodeBorderRadius" nodeBorderRadius
+
+    static member inline nodeStrokeWidth(nodeStrokeWidth: int): IMiniMapProp =
+        Interop.mkMiniMapProp "nodeStrokeWidth" nodeStrokeWidth
+
+    static member inline nodeStrokeWidth(nodeStrokeWidth: float): IMiniMapProp =
+        Interop.mkMiniMapProp "nodeStrokeWidth" nodeStrokeWidth
+
+    static member inline nodeClassName(nodeClassName: string): IMiniMapProp =
+        Interop.mkMiniMapProp "nodeClassName" nodeClassName
+
+    static member inline nodeClassName(nodeClassName: Node -> string): IMiniMapProp =
+        Interop.mkMiniMapProp "nodeClassName" nodeClassName
+
+    static member inline maskColor(maskColor: string): IMiniMapProp =
+        Interop.mkMiniMapProp "maskColor" maskColor
+
+    static member inline style props: IMiniMapProp =
+        Interop.mkMiniMapProp "style" (createObj !!props)
+
+    static member inline className(className: string): IMiniMapProp =
+        Interop.mkMiniMapProp "className" className
+
+
+[<Erase>]
+type controls =
+    // https://reactflow.dev/docs/api/components/minimap/
+
+    static member inline showZoom(showZoom: bool): IControlsProp =
+        Interop.mkControlsProp "showZoom" showZoom
+
+    static member inline showFitView(showFitView: bool): IControlsProp =
+        Interop.mkControlsProp "showFitView" showFitView
+
+    static member inline showInteractive(showInteractive: bool): IControlsProp =
+        Interop.mkControlsProp "showInteractive" showInteractive
+
+    static member inline style props: IControlsProp =
+        Interop.mkControlsProp "style" (createObj !!props)
+
+    static member inline className(className: string): IControlsProp =
+        Interop.mkControlsProp "className" className
+
+    static member inline onZoomIn(onZoomIn: unit -> unit): IControlsProp =
+        Interop.mkControlsProp "onZoomIn" onZoomIn
+
+    static member inline onZoomOut(onZoomOut: unit -> unit): IControlsProp =
+        Interop.mkControlsProp "onZoomOut" onZoomOut
+
+    static member inline onFitView(onFitView: unit -> unit): IControlsProp =
+        Interop.mkControlsProp "onFitView" onFitView
+
+    static member inline onInteractiveChange(onInteractiveChange: bool -> unit): IControlsProp =
+        Interop.mkControlsProp "onInteractiveChange" onInteractiveChange

--- a/src/Feliz.ReactFlow/Feliz.ReactFlow.fsproj
+++ b/src/Feliz.ReactFlow/Feliz.ReactFlow.fsproj
@@ -8,6 +8,7 @@
     <Compile Include="Interop.fs" />
     <Compile Include="Styles.fs" />
     <Compile Include="Handle.fs" />
+    <Compile Include="Components.fs" />
     <Compile Include="Edge.fs" />
     <Compile Include="Node.fs" />
     <Compile Include="ReactFlow.fs" />

--- a/src/Feliz.ReactFlow/Interop.fs
+++ b/src/Feliz.ReactFlow/Interop.fs
@@ -11,9 +11,15 @@ module Interop =
     let inline mkStyleProp (key: string) (value: obj) : IStyleProp = unbox (key, value)
     let inline mkLabelStyleProp (key: string) (value: obj) : ILabelStyleProp = unbox (key, value)
     let inline mkReactFlowProp (key: string) (value: obj) : IReactFlowProp = unbox (key, value)
+    let inline mkBackgroundProp (key: string) (value: obj) : IBackgroundProp = unbox (key, value)
+    let inline mkMiniMapProp (key: string) (value: obj) : IMiniMapProp = unbox (key, value)
+    let inline mkControlsProp (key: string) (value: obj) : IControlsProp = unbox (key, value)
 
-    let reactFlow : obj = importDefault "react-flow-renderer" // import the top-level ReactFlow element
-    let handle : obj = import "Handle" "react-flow-renderer"  // import the Handle component used for building custom nodes
+    let reactFlow : obj = importDefault "react-flow-renderer"
+    let handle : obj = import "Handle" "react-flow-renderer"
+    let background : obj = import "Background" "react-flow-renderer"
+    let miniMap : obj = import "MiniMap" "react-flow-renderer"
+    let controls : obj = import "Controls" "react-flow-renderer"
 
 [<Erase; RequireQualifiedAccess>]
 module Helpers =

--- a/src/Feliz.ReactFlow/Node.fs
+++ b/src/Feliz.ReactFlow/Node.fs
@@ -6,17 +6,38 @@ open Feliz
 
 [<Erase>]
 type node =
+    static member inline id(id: string): INodeProp =
+        Interop.mkNodeProp "id" id
+
     static member inline position(x: int, y: int): INodeProp =
         Interop.mkNodeProp "position" {| x = x; y = y |}
-
-    static member inline nodetype(nodeType: NodeType): INodeProp =
-        Interop.mkNodeProp "type" (nodeType.toString())
 
     static member inline data(data: obj): INodeProp =
         Interop.mkNodeProp "data" data
 
+    static member inline nodetype(nodeType: NodeType): INodeProp =
+        Interop.mkNodeProp "type" (nodeType.toString())
+
     static member inline style props: INodeProp =
         Interop.mkNodeProp "style" (createObj !!props)
 
-    static member inline id(id: string): INodeProp =
-        Interop.mkNodeProp "id" id
+    static member inline className(className: string): INodeProp =
+        Interop.mkNodeProp "className" (createObj !!className)
+
+    static member inline targetPosition(targetPosition: HandlePosition): INodeProp =
+        Interop.mkNodeProp "targetPosition" (createObj !!targetPosition)
+
+    static member inline sourcePosition(sourcePosition: HandlePosition): INodeProp =
+        Interop.mkNodeProp "sourcePosition" (createObj !!sourcePosition)
+
+    static member inline isHidden(isHidden: bool): INodeProp =
+        Interop.mkNodeProp "isHidden" (createObj !!isHidden)
+
+    static member inline draggable(draggable: bool): INodeProp =
+        Interop.mkNodeProp "draggable" (createObj !!draggable)
+
+    static member inline connectable(connectable: bool): INodeProp =
+        Interop.mkNodeProp "connectable" (createObj !!connectable)
+
+    static member inline selectable(selectable: bool): INodeProp =
+        Interop.mkNodeProp "selectable" (createObj !!selectable)

--- a/src/Feliz.ReactFlow/ReactFlow.fs
+++ b/src/Feliz.ReactFlow/ReactFlow.fs
@@ -47,6 +47,7 @@ type OnConnectStartParams =
 [<Erase>]
 type ReactFlow =
     /// Creates a new ReactFlow component.
+
     static member inline flowChart (props: IReactFlowProp seq) =
         Interop.reactApi.createElement (Interop.reactFlow, createObj !!props)
 
@@ -59,6 +60,15 @@ type ReactFlow =
     static member inline handle (props: IHandleProp seq) =
         Interop.reactApi.createElement (Interop.handle, createObj !!props)
 
+    static member inline background (props: IBackgroundProp seq) =
+        Interop.reactApi.createElement (Interop.background, createObj !!props)
+
+    static member inline miniMap (props: IMiniMapProp seq) =
+        Interop.reactApi.createElement (Interop.miniMap, createObj !!props)
+
+    static member inline controls (props: IControlsProp seq) =
+        Interop.reactApi.createElement (Interop.controls, createObj !!props)
+
     // Basic Props
 
     static member inline elements(elements: IElement array) : IReactFlowProp = !!("elements" ==> elements)
@@ -68,6 +78,9 @@ type ReactFlow =
 
     static member inline className(className: string) : IReactFlowProp =
         Interop.mkReactFlowProp "className" className
+
+    static member inline children (children: ReactElement list) =
+        unbox<IReactFlowProp> (prop.children children)
 
     // Flow View
 

--- a/src/Feliz.ReactFlow/ReactFlow.fs
+++ b/src/Feliz.ReactFlow/ReactFlow.fs
@@ -20,6 +20,29 @@ type labelStyle =
     static member inline fill(fill: string) = Interop.mkAttr "fill" fill
     static member inline fontWeight(fontWeight: int) = Interop.mkAttr "fontWeight" fontWeight
 
+[<Erase>]
+type Instance =
+    abstract project: position -> position
+    abstract fitView: {| padding: float ; includeHiddenNodes: bool |} -> unit
+    abstract zoomIn: unit -> unit
+    abstract zoomOut: unit -> unit
+    abstract zoomTo: float -> unit
+    abstract setTransform: {| x: int ;  y: int ; zoom: float |} -> unit
+    abstract toObject: unit -> {| elements: Element list ; position: int * int ; zoom: float |}
+    abstract getElements: unit -> Element list
+
+[<Erase>]
+type OnConnectParams =
+    abstract source: ElementId
+    abstract sourceHandle: Handle
+    abstract target: ElementId
+    abstract targetHandle: Handle
+
+[<Erase>]
+type OnConnectStartParams =
+    abstract nodeId: string
+    abstract handleType: HandleType
+
 // The !! below is used to "unsafely" expose a prop into an IReactFlowProp.
 [<Erase>]
 type ReactFlow =
@@ -109,10 +132,10 @@ type ReactFlow =
     static member inline onNodeDoubleClick(handler: Event -> Node -> unit) : IReactFlowProp =
         !!("onNodeDoubleClick" ==> handler)
 
-    static member inline onConnect(handler: {| source: ElementId ; sourceHandle: Handle ; target: ElementId ; targetHandle: Handle |} -> unit) : IReactFlowProp =
+    static member inline onConnect(handler: OnConnectParams -> unit) : IReactFlowProp =
         !!("onConnect" ==> handler)
 
-    static member inline onConnectStart(handler: Event -> {| nodeId: string; handleType: HandleType |} -> unit) : IReactFlowProp =
+    static member inline onConnectStart(handler: Event -> OnConnectStartParams -> unit) : IReactFlowProp =
         !!("onConnectStart" ==> System.Func<_,_,_>handler)
 
     static member inline onConnectStop(handler: Event -> unit) : IReactFlowProp =
@@ -144,8 +167,8 @@ type ReactFlow =
     static member inline onEdgeUpdateEnd(handler: Event -> Edge -> unit) : IReactFlowProp =
         !!("onEdgeUpdateEnd" ==> handler)
 
-    static member inline onLoad(handler: unit) : IReactFlowProp =
-        !!("onLoad" ==> handler)
+    static member inline onLoad(reactFlowInstance: Instance option -> unit) : IReactFlowProp =
+        !!("onLoad" ==> reactFlowInstance)
 
     static member inline onMove(flowTransform: unit) : IReactFlowProp =
         !!("onMove" ==> flowTransform)

--- a/src/Feliz.ReactFlow/Types.fs
+++ b/src/Feliz.ReactFlow/Types.fs
@@ -10,6 +10,9 @@ type INodeProp = interface end
 type IEdgeProp = interface end
 type IStyleProp = interface end
 type ILabelStyleProp = interface end
+type IBackgroundProp = interface end
+type IMiniMapProp = interface end
+type IControlsProp = interface end
 
 // Some sample types you can use for setting properties on elements.
 [<StringEnum>]


### PR DESCRIPTION
This pull request adds support for the:

- Background, Mini Map and Controls components
- Missing node properties (which are now complete)

It also changes the onLoad, onConnect and onConnectStart types (erase types instead of the anonymous records) to avoid the "Two anonymous record types are from different assemblies" warning when passing and annotating client component properties.
